### PR TITLE
feat(auth): add User model and basic auth utilities (JWT, bcrypt)

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -1,0 +1,21 @@
+Database
+=======
+
+This project now includes a minimal SQLite + SQLAlchemy setup to persist Activities.
+
+Files added:
+- `src/models.py` — SQLAlchemy `Activity` model (simple participants stored as comma-separated string).
+- `scripts/init_db.py` — initialization script that creates the SQLite DB and seeds a few activities.
+
+How to initialize locally:
+
+```bash
+python3 -m pip install -r requirements.txt
+python scripts/init_db.py
+# Start the app
+uvicorn src.app:app --reload
+```
+
+Notes and next steps:
+- Participants are stored as a comma-separated string to keep the data model small for the exercise. We'll normalize this to a join table (ActivityParticipants) when we add users.
+- After DB is initialized, endpoints at `/activities`, `/activities/{name}/signup`, and `/activities/{name}/unregister` use the DB-backed model automatically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 
 sqlalchemy
 alembic
+
+passlib[bcrypt]
+python-jose[cryptography]

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -6,7 +6,8 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from src.models import Base, Activity
+from src.models import Base, Activity, User
+from src.auth import get_password_hash
 
 
 def init_db(db_url: str = None):
@@ -31,6 +32,15 @@ def init_db(db_url: str = None):
         print("Seeded initial activities")
     else:
         print("Database already initialized with activities")
+
+    # Seed admin user if none exists
+    if session.query(User).count() == 0:
+        admin = User(email="admin@mergington.edu", name="Administrator", password_hash=get_password_hash("adminpass"), role="admin")
+        session.add(admin)
+        session.commit()
+        print("Seeded admin user: admin@mergington.edu (password: adminpass)")
+    else:
+        print("Users already exist in database")
 
 
 if __name__ == "__main__":

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from passlib.context import CryptContext
+from jose import JWTError, jwt
+
+# NOTE: In production, move SECRET_KEY to env var and rotate regularly
+SECRET_KEY = "dev-secret-for-exercise"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def decode_access_token(token: str):
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload
+    except JWTError:
+        return None

--- a/src/models.py
+++ b/src/models.py
@@ -26,3 +26,20 @@ class Activity(Base):
 
     def set_participants(self, lst):
         self.participants = ",".join(lst)
+
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    name = Column(String(200), nullable=True)
+    # store bcrypt-hashed password
+    password_hash = Column(String(255), nullable=False)
+    # simple role: user / officer / admin
+    role = Column(String(50), default="user")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    def is_admin(self):
+        return self.role == "admin"


### PR DESCRIPTION
This PR adds a minimal User model and authentication helpers:

- `src/models.py`: adds `User` model (email, name, password_hash, role)
- `src/auth.py`: password hashing and JWT token helpers (dev secret)
- `scripts/init_db.py`: seeds an admin user `admin@mergington.edu` with password `adminpass` when DB is empty
- `requirements.txt`: adds `passlib[bcrypt]` and `python-jose[cryptography]`

Notes:
- Tokens and secret are for development only; move secrets to env vars for production.
- Next steps: add login endpoints, dependency-based route protection, and user management UI.
